### PR TITLE
Make actions clearer

### DIFF
--- a/octoprint_eeprom_marlin/templates/eeprom_marlin_settings.jinja2
+++ b/octoprint_eeprom_marlin/templates/eeprom_marlin_settings.jinja2
@@ -5,7 +5,7 @@ Your machine is <span style="color: red" data-bind="visible: isConnected() && !i
 
 <form class="form-horizontal">
     <button data-bind="enabled: isMarlinFirmware, click: loadEeprom">{{ _('Load EEprom') }}</button>
-    <button data-bind="enabled: isMarlinFirmware, click: saveEeprom">{{ _('Save EEprom') }}</button>
+    <button data-bind="enabled: isMarlinFirmware, click: saveEeprom">{{ _('Save to EEprom') }}</button>
 </form>
 
 <div data-bind="foreach: eepromData">


### PR DESCRIPTION
Changing "Save EEPROM" to "Save to EEPROM" lets people understand they are saving values into their EEPROM, not that they are saving their EEPROM values somewhere.

"Load EEPROM" really doesn't need to say "Load From EEPROM" since I believe a user would understand "Get" and "Put" to correspond to "Load" and "Save To."  When instructions say "Get and Put," buttons should probably use the same terminology so people that are struggeling through English don't have to look up 4 words instead of 2 words.
