### PR TITLE
Disallow loading and communication of EEPROM during print

### DIFF
--- a/octoprint_eeprom_marlin/static/js/eeprom_marlin.js
+++ b/octoprint_eeprom_marlin/static/js/eeprom_marlin.js
@@ -79,6 +79,10 @@ $(function() {
             self.connection.isReady() || self.connection.isPaused();
         });
 
+        self.isPrinting = ko.computed(function() {
+           return self.connection.isPrinting() || self.connection.isPaused();
+        });
+
         self.eepromData1 = ko.observableArray([]);
         self.eepromData2 = ko.observableArray([]);
         self.eepromDataLevel = ko.observableArray([]);
@@ -1730,12 +1734,16 @@ $(function() {
         };
 
         self._requestFirmwareInfo = function() {
-            self.control.sendCustomCommand({ command: "M115" });
+            if (!self.isPrinting()) {
+                self.control.sendCustomCommand({ command: "M115" });
+            }
         };
 
         self._requestEepromData = function() {
-            self.control.sendCustomCommand({ command: "M504" });
-            self.control.sendCustomCommand({ command: "M501" });
+            if (!self.isPrinting()) {
+                self.control.sendCustomCommand({ command: "M504" });
+                self.control.sendCustomCommand({ command: "M501" });
+            }
         };
 
         self._requestSaveDataToEeprom = function(data_type, value) {

--- a/octoprint_eeprom_marlin/templates/eeprom_marlin_settings.jinja2
+++ b/octoprint_eeprom_marlin/templates/eeprom_marlin_settings.jinja2
@@ -2,8 +2,8 @@
 This plugin is designed to get, change and save the values in the EEPROM of your Marlin Firmware based Machine.<br><br>
 <span style="color: red" data-bind="visible: isConnected() && !isMarlinFirmware()">Sorry. This plugin does not work with your machine, only Marlin based firmware</span>
 <span style="color: red" data-bind="visible: !isConnected()">Printer not connected.</span>
-
-<div data-bind="visible: isConnected() && isMarlinFirmware()">
+<span style="color: red" data-bind="visible: isPrinting()">EEPROM settings are disabled if the printer is printing</span>
+<div data-bind="visible: isConnected() && isMarlinFirmware() && !isPrinting() ">
     <!--b>Firmware:</b> <span data-bind="text: firmware_name()"></span!-->
     <form class="form-horizontal">
         <button id="eeprom_marlin_load" data-bind="enabled: isMarlinFirmware, click: loadEeprom" class="btn icon-download-alt" aria-hidden="true">&nbsp;{{ _('Load') }}</button>


### PR DESCRIPTION
In the middle of a print or if the printer is paused for any reason, issuing a M501 can impact the print by resetting variables that are modified for the print via GCODE or other.   

This modification adds a isPrinting check and prevents displaying the administration page as well as the custom calls to the printer if 'true'